### PR TITLE
Fix running the model from the web app

### DIFF
--- a/fludetector/app.py
+++ b/fludetector/app.py
@@ -268,7 +268,7 @@ def admin_run_model(id):
     form = forms.RunModelForm.factory(model)
     if form.validate_on_submit():
         run = sh.Command('./scripts/run.sh')
-        run(str(id), _bg=True, **form.to_dict())
+        run('runmodel', str(id), _bg=True, **form.to_dict())
         flash('Model running in background, check logs for details', 'info')
         return redirect(url_for('admin_list_models'))
     return render_template('admin/model_run.html', form=form, model=model)


### PR DESCRIPTION
Resolves the following:

    Exception in thread background thread for pid 32335:
    Traceback (most recent call last):
      File "/usr/lib64/python2.7/threading.py", line 812, in __bootstrap_inner
	self.run()
      File "/usr/lib64/python2.7/threading.py", line 765, in run
	self.__target(*self.__args, **self.__kwargs)
      File "/opt/fludetector/venv/lib/python2.7/site-packages/sh.py", line 1540, in wrap
	fn(*args, **kwargs)
      File "/opt/fludetector/venv/lib/python2.7/site-packages/sh.py", line 2459, in background_thread
	handle_exit_code(exit_code)
      File "/opt/fludetector/venv/lib/python2.7/site-packages/sh.py", line 2157, in fn
	return self.command.handle_command_exit_code(exit_code)
      File "/opt/fludetector/venv/lib/python2.7/site-packages/sh.py", line 815, in handle_command_exit_code
	raise exc
    ErrorReturnCode_2:

      RAN: /opt/fludetector/scripts/run.sh 1 --start=2018-09-28 --end=2018-09-30

      STDOUT:
     * Tip: There are .env files present. Do "pip install python-dotenv" to use them.

      STDERR:
    Usage: flask [OPTIONS] COMMAND [ARGS]...

    Error: No such command "1".